### PR TITLE
picosoc: enable fast multiply option for icebreaker

### DIFF
--- a/picosoc/Makefile
+++ b/picosoc/Makefile
@@ -57,7 +57,7 @@ icebsynsim: icebreaker_syn_tb.vvp icebreaker_fw.hex
 	vvp -N $< +firmware=icebreaker_fw.hex
 
 icebreaker.json: icebreaker.v ice40up5k_spram.v spimemio.v simpleuart.v picosoc.v ../picorv32.v
-	yosys -ql icebreaker.log -p 'synth_ice40 -top icebreaker -json icebreaker.json' $^
+	yosys -ql icebreaker.log -p 'synth_ice40 -dsp -top icebreaker -json icebreaker.json' $^
 
 icebreaker_tb.vvp: icebreaker_tb.v icebreaker.v ice40up5k_spram.v spimemio.v simpleuart.v picosoc.v ../picorv32.v spiflash.v
 	iverilog -s testbench -o $@ $^ `yosys-config --datdir/ice40/cells_sim.v`
@@ -69,7 +69,7 @@ icebreaker_syn.v: icebreaker.json
 	yosys -p 'read_json icebreaker.json; write_verilog icebreaker_syn.v'
 
 icebreaker.asc: icebreaker.pcf icebreaker.json
-	nextpnr-ice40 --freq 13 --up5k --asc icebreaker.asc --pcf icebreaker.pcf --json icebreaker.json
+	nextpnr-ice40 --freq 13 --up5k --package sg48 --asc icebreaker.asc --pcf icebreaker.pcf --json icebreaker.json
 
 icebreaker.bin: icebreaker.asc
 	icetime -d up5k -c 12 -mtr icebreaker.rpt icebreaker.asc

--- a/picosoc/icebreaker.v
+++ b/picosoc/icebreaker.v
@@ -108,7 +108,9 @@ module icebreaker (
 
 	picosoc #(
 		.BARREL_SHIFTER(0),
-		.ENABLE_MULDIV(0),
+		.ENABLE_MUL(0),
+		.ENABLE_DIV(0),
+		.ENABLE_FAST_MUL(1),
 		.MEM_WORDS(MEM_WORDS)
 	) soc (
 		.clk          (clk         ),

--- a/picosoc/picosoc.v
+++ b/picosoc/picosoc.v
@@ -70,7 +70,9 @@ module picosoc (
 	input  flash_io3_di
 );
 	parameter [0:0] BARREL_SHIFTER = 1;
-	parameter [0:0] ENABLE_MULDIV = 1;
+	parameter [0:0] ENABLE_MUL = 1;
+	parameter [0:0] ENABLE_DIV = 1;
+	parameter [0:0] ENABLE_FAST_MUL = 0;
 	parameter [0:0] ENABLE_COMPRESSED = 1;
 	parameter [0:0] ENABLE_COUNTERS = 1;
 	parameter [0:0] ENABLE_IRQ_QREGS = 0;
@@ -136,8 +138,9 @@ module picosoc (
 		.BARREL_SHIFTER(BARREL_SHIFTER),
 		.COMPRESSED_ISA(ENABLE_COMPRESSED),
 		.ENABLE_COUNTERS(ENABLE_COUNTERS),
-		.ENABLE_MUL(ENABLE_MULDIV),
-		.ENABLE_DIV(ENABLE_MULDIV),
+		.ENABLE_MUL(ENABLE_MUL),
+		.ENABLE_DIV(ENABLE_DIV),
+		.ENABLE_FAST_MUL(ENABLE_FAST_MUL),
 		.ENABLE_IRQ(1),
 		.ENABLE_IRQ_QREGS(ENABLE_IRQ_QREGS)
 	) cpu (


### PR DESCRIPTION
This patch splits the picosoc's `ENABLE_MULDIV` paramter into `ENABLE_MUL`, `ENABLE_DIV` and `ENABLE_FAST_MUL`,
and also enables the DSP-based fast multiplier for the iCE40up5k icebreaker board.