### PR TITLE
README.md: drop dead tool reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ PicoRV32 is a CPU core that implements the [RISC-V RV32IMC Instruction Set](http
 It can be configured as RV32E, RV32I, RV32IC, RV32IM, or RV32IMC core, and optionally
 contains a built-in interrupt controller.
 
-Tools (gcc, binutils, etc..) can be obtained via the [RISC-V Website](https://riscv.org/software-status/).
-The examples bundled with PicoRV32 expect various RV32 toolchains to be installed in `/opt/riscv32i[m][c]`. See
-the [build instructions below](#building-a-pure-rv32i-toolchain) for details.
 Many Linux distributions now include the tools for RISC-V (for example
 Ubuntu 20.04 has `gcc-riscv64-unknown-elf`). To compile using those set
 `TOOLCHAIN_PREFIX` accordingly (eg. `make TOOLCHAIN_PREFIX=riscv64-unknown-elf-`).
+Alternatively, see the [build instructions below](#building-a-pure-rv32i-toolchain)
+to build the toolsfrom source.
 
 PicoRV32 is free and open hardware licensed under the [ISC license](http://en.wikipedia.org/wiki/ISC_license)
 (a license that is similar in terms to the MIT license or the 2-clause BSD license).


### PR DESCRIPTION
The URL https://riscv.org/software-status/ doesn't work anymore and
for all modern distros, the supplied tools will work just fine.  I
suspect most will find this the easier path.