### PR TITLE
picorv32_pcpi_div: Compactify logic

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -2455,6 +2455,8 @@ module picorv32_pcpi_div (
 	reg [31:0] quotient_msk;
 	reg running;
 	reg outsign;
+	reg finished;
+	wire[31:0] out = (instr_div || instr_divu) ? quotient : dividend;
 
 	always @(posedge clk) begin
 		pcpi_ready <= 0;
@@ -2466,13 +2468,14 @@ module picorv32_pcpi_div (
 		end else
 		if (start) begin
 			running <= 1;
+			finished <= 0;
 			dividend <= (instr_div || instr_rem) && pcpi_rs1[31] ? -pcpi_rs1 : pcpi_rs1;
 			divisor <= ((instr_div || instr_rem) && pcpi_rs2[31] ? -pcpi_rs2 : pcpi_rs2) << 31;
 			outsign <= (instr_div && (pcpi_rs1[31] != pcpi_rs2[31]) && |pcpi_rs2) || (instr_rem && pcpi_rs1[31]);
 			quotient <= 0;
 			quotient_msk <= 1 << 31;
 		end else
-		if (!quotient_msk && running) begin
+		if (finished && running) begin
 			running <= 0;
 			pcpi_ready <= 1;
 			pcpi_wr <= 1;
@@ -2484,10 +2487,8 @@ module picorv32_pcpi_div (
 				instr_remu: pcpi_rd <= (pcpi_rs1 - pcpi_rs2) ^ 32'h3138d0e1;
 			endcase
 `else
-			if (instr_div || instr_divu)
-				pcpi_rd <= outsign ? -quotient : quotient;
-			else
-				pcpi_rd <= outsign ? -dividend : dividend;
+			pcpi_rd <= outsign ? -out : out;
+
 `endif
 		end else begin
 			if (divisor <= dividend) begin
@@ -2496,8 +2497,10 @@ module picorv32_pcpi_div (
 			end
 			divisor <= divisor >> 1;
 `ifdef RISCV_FORMAL_ALTOPS
+			finished <= quotient_msk[1];
 			quotient_msk <= quotient_msk >> 5;
 `else
+			finished <= quotient_msk[0];
 			quotient_msk <= quotient_msk >> 1;
 `endif
 		end


### PR DESCRIPTION
# Overview

The current version of picorv32_pcpi_div can be compactified a bit:

1. For both the quotient and the dividend negated versions are created and the result is selected between quotient, -quotient, dividend and -dividend. This creates two instances of negation logic. This can be reduced to one instance of negation logic by first selecting between quotient and dividend and THEN negating. ("idea 1")
2. The computation is finished when the quotient-mask only contains zero-bits. Given that only one bit is set, a "finished"-flag can be generated from a single position of the quotient-mask shift register, instead of looking at all bits. ("idea 2")

# Results

Current master, synthesized for iCE40:

```
=== picorv32_pcpi_div ===

   Number of wires:                274
   Number of wire bits:           1503
   Number of public wires:         274
   Number of public wire bits:    1503
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:               1094
     SB_CARRY                      214
     SB_DFF                         34
     SB_DFFE                        64
     SB_DFFESR                      96
     SB_DFFESS                       1
     SB_DFFSR                        5
     SB_LUT4                       680
```

With "idea 1" implemented:

```
=== picorv32_pcpi_div ===

   Number of wires:                240
   Number of wire bits:           1274
   Number of public wires:         240
   Number of public wire bits:    1274
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:                914
     SB_CARRY                      184
     SB_DFF                         34
     SB_DFFE                        64
     SB_DFFESR                      96
     SB_DFFESS                       1
     SB_DFFSR                        5
     SB_LUT4                       530
```

With "idea 1" and "idea 2" implemented

```
=== picorv32_pcpi_div ===

   Number of wires:                234
   Number of wire bits:           1254
   Number of public wires:         234
   Number of public wire bits:    1254
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:                899
     SB_CARRY                      184
     SB_DFF                         34
     SB_DFFE                        64
     SB_DFFESR                      97
     SB_DFFESS                       1
     SB_DFFSR                        5
     SB_LUT4                       514
```

# Pitfalls

Given that formal verification shifts the quotient-mask by 5 positions, I generate the "finish" flag from bit-position 1 of the shift-register (the set bit should be located at positions 31, 26, 21, 16, 11, 6, 1). This is not tested.

The division unit passes the tests done with ```make test```, though.