### PR TITLE
firmware: fix unaligned symbol problem

### DIFF
--- a/firmware/start.S
+++ b/firmware/start.S
@@ -327,9 +327,7 @@ irq_vec:
 
 	picorv32_retirq_insn()
 
-#ifndef ENABLE_QREGS
 .balign 0x200
-#endif
 irq_regs:
 	// registers are saved to this memory region during interrupt handling
 	// the program counter is saved as register 0


### PR DESCRIPTION
This PR fixes the problem mentioned in Issue #210 .

The symbol `irq_regs` in `firmware/start.S` is possibly unaligned when compiled to support compressed instructions. However, `irq_regs` is further loaded into `sp` register and involved in memory access, which results in unaligned memory access problem.

This PR forces `irq_regs` to always be aligned with `.balign 0x200`, by doing this solves the problem.