### PR TITLE
Enhancement: set new_ascii_instr to UNDEFINED by default

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -698,7 +698,7 @@ module picorv32 #(
 	`FORMAL_KEEP reg dbg_rs2val_valid;
 
 	always @* begin
-		new_ascii_instr = "";
+		new_ascii_instr = "UNDEFINED";
 
 		if (instr_lui)      new_ascii_instr = "lui";
 		if (instr_auipc)    new_ascii_instr = "auipc";


### PR DESCRIPTION
Hi there!

It looks more practical to have a default name for `new_ascii_instr` for debug purposes.
Please feel free to edit the pull request to rename it.