### PR TITLE
Fix RV32E shifts by immediates >= 0x10

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -652,7 +652,8 @@ module picorv32 #(
 	reg instr_getq, instr_setq, instr_retirq, instr_maskirq, instr_waitirq, instr_timer;
 	wire instr_trap;
 
-	reg [regindex_bits-1:0] decoded_rd, decoded_rs1, decoded_rs2;
+	reg [regindex_bits-1:0] decoded_rd, decoded_rs1;
+	reg [4:0] decoded_rs2;
 	reg [31:0] decoded_imm, decoded_imm_j;
 	reg decoder_trigger;
 	reg decoder_trigger_q;


### PR DESCRIPTION
This fixes #211.

I haven't found any other broken instructions on RV32E, but I haven't done rigorous testing.

A cursory check suggests this change doesn't break the Q register instructions in RV32I, but I haven't tested that at all.