### PR TITLE
rename variable `CCFLAGS` to `CFLAGS`

### DIFF
--- a/scripts/cxxdemo/Makefile
+++ b/scripts/cxxdemo/Makefile
@@ -3,7 +3,7 @@ CXX = $(RISCV_TOOLS_PREFIX)g++
 CC = $(RISCV_TOOLS_PREFIX)gcc
 AS = $(RISCV_TOOLS_PREFIX)gcc
 CXXFLAGS = -MD -Os -Wall -std=c++11
-CCFLAGS = -MD -Os -Wall -std=c++11
+CFLAGS = -MD -Os -Wall -std=c++11
 LDFLAGS = -Wl,--gc-sections
 LDLIBS = -lstdc++
 


### PR DESCRIPTION
`CCFLAGS` doesn't exist in my Make version as far as I'm aware.
 I think it should be `CFLAGS`.
 
 
 Here is a quick reference: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#index-CFLAGS