### PR TITLE
Adding ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,35 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - run: yosys --version
+
+  riscv-formal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout picorv32.v
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            picorv32.v
+          sparse-checkout-cone-mode: false
+      - name: Checkout riscv-formal
+        uses: actions/checkout@v4
+        with:
+          repository: YosysHQ/riscv-formal
+          path: riscv-formal
+      - name: cp picorv32.v
+        run: |
+          cp picorv32.v -t riscv-formal/cores/picorv32
+
+      - uses: YosysHQ/setup-oss-cad-suite@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: make checks
+        run: |
+          cd riscv-formal/cores/picorv32
+          make checks -j$(nproc)
+      - name: make check
+        run: |
+          cd riscv-formal/cores/picorv32
+          make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  oss-test:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: YosysHQ/setup-oss-cad-suite@v3
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-    - run: yosys --version
-
   riscv-formal:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  oss-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: YosysHQ/setup-oss-cad-suite@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: yosys --version


### PR DESCRIPTION
Introduce Github Actions to run tests for PRs to avoid breaking changes.

Currently provides a `riscv-formal` job, using the oss-cad-suite to run the riscv-formal picorv32 checks.  Similar to the [riscv-formal CI](https://github.com/YosysHQ/riscv-formal/blob/main/.github/workflows/ci.yml) except we don't need to test NERV, and we want to test the current version of `picorv32.v` rather than the latest master.

Ideally we would also have a job for running `make test` etc, but setting up the riscv-gnu-toolchain is a bit more involved.